### PR TITLE
fix(intruder_alarm): fix build with `std` feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: rust
 rust: nightly
 
+env:
+- FEATURES="std"
+- FEATURES=""
+
 script:
-- cargo test
+- cd intruder_alarm
+# we have to cd into the dir rather than using cargo test -p
+# since cargo test -p won't pass feature flags.
+- cargo test --features=$FEATURES
+- cd ..
+- cargo test --features=$FEATURES

--- a/intruder_alarm/Cargo.toml
+++ b/intruder_alarm/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [features]
 std = []
+alloc = []
 
 [dev-dependencies]
 quickcheck = "0.4.1"

--- a/intruder_alarm/src/doubly/mod.rs
+++ b/intruder_alarm/src/doubly/mod.rs
@@ -336,10 +336,14 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(
+    feature = "alloc",
+    not(any(feature = "std", test))
+))]
 use alloc::boxed::Box;
 #[cfg(any(feature = "std", test))]
-use core::boxed::Box;
+use std::boxed::Box;
+
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
 impl<T, Node> List<T, Node, Box<Node>>

--- a/intruder_alarm/src/lib.rs
+++ b/intruder_alarm/src/lib.rs
@@ -25,7 +25,13 @@
 //! + `std`: use the Rust standard library (`std`), rather than `core`.
 #![crate_name = "intruder_alarm"]
 #![crate_type = "lib"]
-#![cfg_attr(not(test), no_std)]
+// Use `no_std` attribute unless we are running tests or compiling with
+// the "std" feature.
+#![cfg_attr(
+    not(any(test, feature = "std")),
+    no_std
+)]
+#![cfg_attr(feature = "alloc", feature(alloc))]
 #![feature(shared)]
 #![feature(const_fn)]
 #![deny(missing_docs)]
@@ -35,7 +41,7 @@
 extern crate quickcheck;
 
 #[cfg(any(feature = "std", test))]
-use std as core;
+extern crate core;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -94,10 +100,13 @@ unsafe impl<'a, T: ?Sized> OwningRef<T> for &'a mut T {
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(
+    feature = "alloc",
+    not(any(feature = "std", test))
+))]
 use alloc::boxed::Box;
 #[cfg(any(feature = "std", test))]
-use core::boxed::Box;
+use std::boxed::Box;
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
 unsafe impl<T: ?Sized> OwningRef<T> for Box<T> {


### PR DESCRIPTION
Thanks to @leshow for reporting.

I've added a Travis build with the `std` feature flag, and fixed the conditional compilation so that build passes.

Closes #20