### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# as the project maintainer, Eliza should review all PRs.
+*   @hawkw
+
+# intruder_alarm's singly-linked list implementation was
+# originally contributed by @amanjeev, so he should review
+# any changes to it.
+intruder_alarm/src/singly/  @amanjeev @hawkw
+
+# @leshow is now our resident rustfmt expert.
+rustfmt.toml    @leshow @hawkw


### PR DESCRIPTION
The [CODEOWNERS file](https://github.com/blog/2392-introducing-code-owners) will configure GitHub to automatically add certain users as reviewers for pull requests that change certain files.

@leshow and @amanjeev, how do you feel about being added to the list of code owners?