### PR TITLE
Add locked allocator type to alloc-base

### DIFF
--- a/alarm_base/Cargo.toml
+++ b/alarm_base/Cargo.toml
@@ -8,9 +8,8 @@ Base types and API definitions shared across ALARM allocators.
 
 [features]
 default = ["lend"]
-lend = ["spin"]
+lend = []
 std = []
 
 [dependencies.spin]
-optional = true
 version = "0.4.6"


### PR DESCRIPTION
This simplifies the lend allocator implementation and will make allocator composition/stacking much easier further on.