### PR TITLE
feat(intruder_alarm::doubly::List): add immutable cursor for doubly-linked lists

### DIFF
--- a/intruder_alarm/src/cursor.rs
+++ b/intruder_alarm/src/cursor.rs
@@ -8,7 +8,7 @@
 //
 //! Cursors allowing bi-directional traversal of data structures.
 use core::{iter, ops};
-use ::OwningRef;
+use OwningRef;
 
 //-----------------------------------------------------------------------------
 // Traits
@@ -35,7 +35,7 @@ pub trait Cursor {
 
     /// Move the cursor `n` elements back.
     #[inline]
-    fn seek_back(&mut self, n: usize)  -> &mut Self {
+    fn seek_back(&mut self, n: usize) -> &mut Self {
         for _ in 0..n {
             self.move_back();
         }
@@ -147,12 +147,14 @@ where
     /// Insert the given node before the cursor's position.
     // TODO: ops::Place impl?
     fn insert_node_before(&mut self, mut node: Self::Ref) -> &mut Self
-    where Self::Ref: ops::DerefMut;
+    where
+        Self::Ref: ops::DerefMut;
 
     /// Insert the given node after the cursor's position.
     // TODO: ops::Place impl?
     fn insert_node_after(&mut self, node: Self::Ref) -> &mut Self
-    where Self::Ref: ops::DerefMut;
+    where
+        Self::Ref: ops::DerefMut;
 
     /// Iterate over each item in the data structure and mutate it in place
     /// with function `f`.
@@ -167,7 +169,7 @@ where
                 false
             } else {
                 // Otherwise, we've reached the end of the data structure.
-               true
+                true
             };
 
             if done {

--- a/intruder_alarm/src/cursor.rs
+++ b/intruder_alarm/src/cursor.rs
@@ -75,7 +75,6 @@ where
     /// The type of [`OwningRef`] used by the parent data structure.
     type Ref: OwningRef<N>;
 
-    // TODO: some kind of `map`-like mutate in place function?
     /// Return a reference to the item currently under the cursor.
     fn get_mut(&mut self) -> Option<&mut T>;
 
@@ -154,6 +153,26 @@ where
     /// Insert the given item after the cursor's position.
     // TODO: ops::Place impl?
     fn insert_after(&mut self, item: T);
+
+    /// Iterate over each item in the data structure and mutate it in place
+    /// with function `f`.
+    fn map_in_place<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut Self::Item),
+    {
+        loop {
+            if let Some(ref mut i) = self.get_mut() {
+                // If there is an item under the cursor, mutate it with `f`.
+                f(i);
+            } else {
+                // Otherwise, we've reached the end of the data structure.
+                return;
+            };
+
+            // Advance the cursor to the next element.
+            self.move_forward();
+        }
+    }
 }
 
 /// Conversion into a `Cursor``.

--- a/intruder_alarm/src/cursor.rs
+++ b/intruder_alarm/src/cursor.rs
@@ -7,7 +7,7 @@
 //  directory of this repository for more information.
 //
 //! Cursors allowing bi-directional traversal of data structures.
-use core::iter;
+use core::{iter, ops};
 use ::OwningRef;
 
 //-----------------------------------------------------------------------------
@@ -146,13 +146,15 @@ where
         items
     }
 
-    /// Insert the given item before the cursor's position.
+    /// Insert the given node before the cursor's position.
     // TODO: ops::Place impl?
-    fn insert_before(&mut self, item: T);
+    fn insert_node_before(&mut self, mut node: Self::Ref)
+    where Self::Ref: ops::DerefMut;
 
-    /// Insert the given item after the cursor's position.
+    /// Insert the given node after the cursor's position.
     // TODO: ops::Place impl?
-    fn insert_after(&mut self, item: T);
+    fn insert_node_after(&mut self, node: Self::Ref)
+    where Self::Ref: ops::DerefMut;
 
     /// Iterate over each item in the data structure and mutate it in place
     /// with function `f`.

--- a/intruder_alarm/src/lib.rs
+++ b/intruder_alarm/src/lib.rs
@@ -81,7 +81,7 @@ pub struct UnsafeRef<T: ?Sized>(NonNull<T>);
 
 /// A `Link` provides an [`Option`]-like interface to a [`NonNull`] pointer.
 ///
-///
+#[derive(Eq, PartialEq)]
 pub struct Link<T: ?Sized>(Option<NonNull<T>>);
 
 // ===== impl OwningRef =====

--- a/intruder_alarm/src/lib.rs
+++ b/intruder_alarm/src/lib.rs
@@ -313,8 +313,8 @@ impl<T: ?Sized> Link<T> {
 
     /// Take `self`, replacing it with `None`
     #[inline]
-    fn take(&mut self) -> Option<Link<T>> {
-        self.0.take().map(|x| Link(Some(x)))
+    fn take(&mut self) -> Option<NonNull<T>> {
+        self.0.take()
     }
 
     /// Swaps the pointed value with `with`, returning the previous pointer.

--- a/intruder_alarm/src/lib.rs
+++ b/intruder_alarm/src/lib.rs
@@ -278,7 +278,7 @@ impl<T: ?Sized> Link<T> {
     /// # Unsafe due to
     ///   - Returning a reference with an arbitrary lifetime
     ///   - Dereferencing a raw pointer
-    fn as_ref(&self) -> Option<&T> {
+    fn as_ref<'a>(&'a self) -> Option<&'a T> {
         self.0.as_ref().map(|shared| unsafe { shared.as_ref() })
     }
 

--- a/intruder_alarm/src/list/mod.rs
+++ b/intruder_alarm/src/list/mod.rs
@@ -558,12 +558,14 @@ where
 {
     type Item = T;
 
-    fn move_forward(&mut self) {
+    fn move_forward(&mut self) -> &mut Self {
         self.current = self.current.and_then(Linked::next);
+        self
     }
 
-    fn move_back(&mut self) {
+    fn move_back(&mut self) -> &mut Self {
         self.current = self.current.and_then(Linked::prev);
+        self
     }
 
     fn get(&self) -> Option<&Self::Item> {
@@ -615,22 +617,24 @@ where
 {
     type Item = T;
 
-    fn move_forward(&mut self) {
+    fn move_forward(&mut self)-> &mut Self {
         self.current = self.current.as_ref()
             .and_then(Linked::next)
             .map(|next|
                 Link::from_owning_ref(UnsafeRef::from(next))
             )
             .unwrap_or_else(Link::none);
+        self
     }
 
-    fn move_back(&mut self) {
+    fn move_back(&mut self) -> &mut Self {
         self.current = self.current.as_ref()
             .and_then(Linked::prev)
             .map(|prev|
                 Link::from_owning_ref(UnsafeRef::from(prev))
             )
             .unwrap_or_else(Link::none);
+        self
     }
 
     fn get(&self) -> Option<&Self::Item> {
@@ -709,7 +713,7 @@ where
     }
 
     /// Insert the given item before the cursor's position.
-    fn insert_node_before(&mut self, mut node: Self::Ref)
+    fn insert_node_before(&mut self, mut node: Self::Ref) -> &mut Self
     where
         Self::Ref: DerefMut,
     {
@@ -744,10 +748,11 @@ where
         }
         self.current = node;
         self.list.len += 1;
+        self
     }
 
     /// Insert the given item after the cursor's position.
-    fn insert_node_after(&mut self, mut node: Self::Ref)
+    fn insert_node_after(&mut self, mut node: Self::Ref) -> &mut Self
     where
         Self::Ref: DerefMut,
     {
@@ -779,5 +784,6 @@ where
         }
 
         self.list.len += 1;
+        self
     }
 }

--- a/intruder_alarm/src/list/mod.rs
+++ b/intruder_alarm/src/list/mod.rs
@@ -7,8 +7,8 @@
 //! use intrusive lists in code that runs without the kernel memory allocator,
 //! like the allocator implementation itself, since each list element manages
 //! its own memory.
-use ::{Link, OwningRef, UnsafeRef};
-use ::cursor::{self, Cursor as CursorTrait };
+use cursor::{self, Cursor as CursorTrait};
+use {Link, OwningRef, UnsafeRef};
 
 use core::iter::{self, DoubleEndedIterator, Extend, FromIterator, Iterator};
 use core::marker::PhantomData;
@@ -347,7 +347,6 @@ where
         Cursor {
             current: self.head.as_ref(),
             _marker: PhantomData,
-
         }
     }
 
@@ -617,22 +616,22 @@ where
 {
     type Item = T;
 
-    fn move_forward(&mut self)-> &mut Self {
-        self.current = self.current.as_ref()
+    fn move_forward(&mut self) -> &mut Self {
+        self.current = self
+            .current
+            .as_ref()
             .and_then(Linked::next)
-            .map(|next|
-                Link::from_owning_ref(UnsafeRef::from(next))
-            )
+            .map(|next| Link::from_owning_ref(UnsafeRef::from(next)))
             .unwrap_or_else(Link::none);
         self
     }
 
     fn move_back(&mut self) -> &mut Self {
-        self.current = self.current.as_ref()
+        self.current = self
+            .current
+            .as_ref()
             .and_then(Linked::prev)
-            .map(|prev|
-                Link::from_owning_ref(UnsafeRef::from(prev))
-            )
+            .map(|prev| Link::from_owning_ref(UnsafeRef::from(prev)))
             .unwrap_or_else(Link::none);
         self
     }
@@ -642,11 +641,17 @@ where
     }
 
     fn peek_next(&self) -> Option<&Self::Item> {
-        self.current.as_ref().and_then(Linked::next).map(Node::as_ref)
+        self.current
+            .as_ref()
+            .and_then(Linked::next)
+            .map(Node::as_ref)
     }
 
     fn peek_back(&self) -> Option<&Self::Item> {
-        self.current.as_ref().and_then(Linked::prev).map(Node::as_ref)
+        self.current
+            .as_ref()
+            .and_then(Linked::prev)
+            .map(Node::as_ref)
     }
 }
 
@@ -666,13 +671,19 @@ where
 
     /// Return a reference to the next element from the cursor's position.
     fn peek_next_mut(&mut self) -> Option<&mut T> {
-        self.current.as_mut().and_then(Linked::next_mut).map(Node::as_mut)
+        self.current
+            .as_mut()
+            .and_then(Linked::next_mut)
+            .map(Node::as_mut)
     }
 
     /// Return a reference to the previous element from the cursor's
     /// position.
     fn peek_back_mut(&mut self) -> Option<&mut T> {
-        self.current.as_mut().and_then(Linked::prev_mut).map(Node::as_mut)
+        self.current
+            .as_mut()
+            .and_then(Linked::prev_mut)
+            .map(Node::as_mut)
     }
 
     /// Remove the element currently under the cursor.
@@ -722,7 +733,9 @@ where
         {
             let links = node.links_mut();
             links.next = self.current;
-            links.prev = self.current.as_ref()
+            links.prev = self
+                .current
+                .as_ref()
                 .map(|current| current.links().prev)
                 .unwrap_or_else(Link::none);
         }
@@ -761,7 +774,9 @@ where
         {
             let links = node.links_mut();
             links.prev = self.current;
-            links.next = self.current.as_ref()
+            links.next = self
+                .current
+                .as_ref()
                 .map(|current| current.links().next)
                 .unwrap_or_else(Link::none);
         }

--- a/intruder_alarm/src/list/tests.rs
+++ b/intruder_alarm/src/list/tests.rs
@@ -74,6 +74,56 @@ mod boxed {
 
     pub type NumberedList = List<usize, NumberedNode, Box<NumberedNode>>;
 
+    mod cursor {
+        use super::*;
+        use ::Cursor;
+        use quickcheck::TestResult;
+
+        quickcheck! {
+            fn cursor_empty_after_n_iterations(xs: Vec<usize>) -> TestResult {
+                let mut list = NumberedList::new();
+                for x in xs {
+                    list.push_back(x);
+                }
+                let mut cursor = list.cursor();
+
+                if !list.is_empty() {
+                    // if the list is not empty, try to cursor over it.
+                    for _ in 0..list.len() - 1 {
+                        if cursor.next_item().is_none() {
+                            return TestResult::failed();
+                        }
+                    }
+                }
+
+                if cursor.next_item().is_some() {
+                    return TestResult::failed();
+                }
+
+                TestResult::passed()
+
+            }
+
+            fn cursor_same_as_vec_iterator(xs: Vec<usize>) -> TestResult {
+                let mut list = NumberedList::new();
+                for x in xs.clone() {
+                    list.push_back(x);
+                }
+                let mut cursor = list.cursor();
+
+                // if the list is not empty, try to cursor over it.
+                for x in &xs {
+                    if cursor.next_item().unwrap() != x {
+                        return TestResult::failed();
+                    }
+                }
+
+                TestResult::passed()
+
+            }
+        }
+    }
+
     mod push_node {
         use super::*;
         use std::boxed::Box;

--- a/intruder_alarm/src/list/tests.rs
+++ b/intruder_alarm/src/list/tests.rs
@@ -267,6 +267,25 @@ macro_rules! gen_cursor_tests {
 
                 }
             }
+
+            fn cursor_mut_map_in_place(xs: Vec<usize>, add: usize) -> TestResult {
+                let mut list = $list::new();
+                for x in xs.clone() {
+                    list.push_back_node($node_ctor(NumberedNode::new(x)));
+                }
+
+                let mut xs = xs;
+                for x in &mut xs {
+                    *x += add;
+                }
+
+                list.cursor_mut().map_in_place(|x| { *x += add; });
+
+                let list_contents = list.cursor().map(|&x| x).collect::<Vec<usize>>();
+                assert_eq!(xs, list_contents, "post-mutation check");
+
+                return TestResult::passed();
+            }
         }
     }
 }

--- a/intruder_alarm/src/list/tests.rs
+++ b/intruder_alarm/src/list/tests.rs
@@ -227,12 +227,9 @@ macro_rules! gen_cursor_tests {
                     {
                         // Only hang on to the cursor for this scope, so we can
                         // release the mutable borrow on the list at the end.
-                        let mut cursor = list.cursor_mut();
-
-                        // Move the cursor to the correct position.
-                        cursor.seek_forward(i);
-
-                        cursor.insert_node_before($node_ctor(NumberedNode::new(insert)));
+                        list.cursor_mut()
+                            .seek_forward(i)
+                            .insert_node_before($node_ctor(NumberedNode::new(insert)));
                     }
 
                     assert_eq!(list.len(), starting_len + 1);
@@ -262,9 +259,9 @@ macro_rules! gen_cursor_tests {
 
                         xs.insert(*at, *insert);
 
-                        let mut cursor = list.cursor_mut();
-                        cursor.seek_forward(*at);
-                        cursor.insert_node_before($node_ctor(NumberedNode::new(*insert)));
+                        list.cursor_mut()
+                            .seek_forward(*at)
+                            .insert_node_before($node_ctor(NumberedNode::new(*insert)));
                     }
 
                     assert_eq!(list.len(), starting_len + insertions.len());
@@ -289,18 +286,9 @@ macro_rules! gen_cursor_tests {
                     let mut xs = xs;
                     xs.insert(i, insert);
 
-                    {
-                        // Only hang on to the cursor for this scope, so we can
-                        // release the mutable borrow on the list at the end.
-                        let mut cursor = list.cursor_mut();
-
-                        // Move the cursor to the correct position.
-                        // for _ in 0..i - 1 {
-                        //     cursor.move_forward();
-                        // }
-                        cursor.seek_forward(i - 1);
-                        cursor.insert_node_after($node_ctor(NumberedNode::new(insert)));
-                    }
+                    list.cursor_mut()
+                        .seek_forward(i - 1)
+                        .insert_node_after($node_ctor(NumberedNode::new(insert)));
 
                     assert_eq!(list.len(), starting_len + 1);
 
@@ -333,9 +321,9 @@ macro_rules! gen_cursor_tests {
 
                         xs.insert(*at, *insert);
 
-                        let mut cursor = list.cursor_mut();
-                        cursor.seek_forward(*at - 1);
-                        cursor.insert_node_after($node_ctor(NumberedNode::new(*insert)));
+                        list.cursor_mut()
+                            .seek_forward(*at - 1)
+                            .insert_node_after($node_ctor(NumberedNode::new(*insert)));
                     }
 
                     assert_eq!(list.len(), starting_len + insertions.len());

--- a/intruder_alarm/src/list/tests.rs
+++ b/intruder_alarm/src/list/tests.rs
@@ -113,9 +113,10 @@ mod boxed {
 
                 // if the list is not empty, try to cursor over it.
                 for x in &xs {
-                    if cursor.next_item().unwrap() != x {
+                    if cursor.get().unwrap() != x {
                         return TestResult::failed();
                     }
+                    cursor.move_forward();
                 }
 
                 TestResult::passed()


### PR DESCRIPTION
Forgot I had this branch open but no PR for it!