### PR TITLE
chore: misc. cleanup

### DIFF
--- a/intruder_alarm/src/cursor.rs
+++ b/intruder_alarm/src/cursor.rs
@@ -146,7 +146,7 @@ where
 
     /// Insert the given node before the cursor's position.
     // TODO: ops::Place impl?
-    fn insert_node_before(&mut self, mut node: Self::Ref) -> &mut Self
+    fn insert_node_before(&mut self, node: Self::Ref) -> &mut Self
     where
         Self::Ref: ops::DerefMut;
 

--- a/intruder_alarm/src/lib.rs
+++ b/intruder_alarm/src/lib.rs
@@ -50,9 +50,9 @@ extern crate alloc;
 use core::{
     borrow::Borrow,
     default::Default,
+    fmt,
     ops::{Deref, DerefMut},
     ptr::NonNull,
-    fmt,
 };
 
 pub mod cursor;

--- a/intruder_alarm/src/lib.rs
+++ b/intruder_alarm/src/lib.rs
@@ -47,11 +47,13 @@ extern crate core;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-use core::borrow::Borrow;
-use core::default::Default;
-use core::ops::{Deref, DerefMut};
-use core::ptr::NonNull;
-use core::{fmt, mem};
+use core::{
+    borrow::Borrow,
+    default::Default,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+    fmt,
+};
 
 pub mod cursor;
 pub use self::cursor::{Cursor, CursorMut};
@@ -146,7 +148,7 @@ impl<T: ?Sized> UnsafeRef<T> {
         )
     )]
     pub fn from_box(b: Box<T>) -> Self {
-        unsafe { UnsafeRef(Box::into_raw_non_null(b)) }
+        UnsafeRef(Box::into_raw_non_null(b))
     }
 
     /// Construct a new `UnsafeRef` from a `T`, using `Box::new` to allocate a
@@ -297,30 +299,6 @@ impl<T: ?Sized> Link<T> {
 
     unsafe fn as_ptr(&mut self) -> Option<*mut T> {
         self.0.as_mut().map(|shared| shared.as_ptr())
-    }
-
-    /// Returns true if this link is empty.
-    #[inline]
-    fn is_none(&self) -> bool {
-        self.0.is_none()
-    }
-
-    /// Returns true if this link is non-empty.
-    #[inline]
-    fn is_some(&self) -> bool {
-        self.0.is_some()
-    }
-
-    /// Take `self`, replacing it with `None`
-    #[inline]
-    fn take(&mut self) -> Option<NonNull<T>> {
-        self.0.take()
-    }
-
-    /// Swaps the pointed value with `with`, returning the previous pointer.
-    #[inline]
-    unsafe fn replace<I: Into<Link<T>>>(&mut self, with: I) -> Link<T> {
-        mem::replace(self, with.into())
     }
 
     fn from_owning_ref<R>(reference: R) -> Self

--- a/intruder_alarm/src/list/mod.rs
+++ b/intruder_alarm/src/list/mod.rs
@@ -8,12 +8,16 @@
 //! like the allocator implementation itself, since each list element manages
 //! its own memory.
 use cursor::{self, Cursor as CursorTrait};
-use {Link, OwningRef, UnsafeRef};
+use Link;
+use OwningRef;
+use UnsafeRef;
 
-use core::iter::{DoubleEndedIterator, Extend, FromIterator, Iterator};
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::DerefMut;
+use core::{
+    iter::{DoubleEndedIterator, Extend, FromIterator, Iterator},
+    marker::PhantomData,
+    mem,
+    ops::DerefMut,
+};
 
 #[cfg(test)]
 mod tests;

--- a/intruder_alarm/src/list/mod.rs
+++ b/intruder_alarm/src/list/mod.rs
@@ -10,7 +10,7 @@
 use cursor::{self, Cursor as CursorTrait};
 use {Link, OwningRef, UnsafeRef};
 
-use core::iter::{self, DoubleEndedIterator, Extend, FromIterator, Iterator};
+use core::iter::{DoubleEndedIterator, Extend, FromIterator, Iterator};
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::DerefMut;
@@ -532,12 +532,6 @@ impl<T> Links<T> {
     #[inline]
     fn prev_mut(&mut self) -> Option<&mut T> {
         self.prev.as_mut()
-    }
-
-    /// Returns true if this set of links is a member of a list.
-    #[inline]
-    fn is_linked(&self) -> bool {
-        self.next.is_some()
     }
 }
 

--- a/intruder_alarm/src/list/tests.rs
+++ b/intruder_alarm/src/list/tests.rs
@@ -6,8 +6,7 @@
 //  directory of this repository for more information.
 //
 
-use super::Linked;
-use super::*;
+use super::{Linked, *};
 use quickcheck::TestResult;
 use std::default::Default;
 
@@ -20,7 +19,7 @@ pub struct NumberedNode {
 impl NumberedNode {
     pub fn new(number: usize) -> Self {
         NumberedNode {
-            number: number,
+            number,
             ..Default::default()
         }
     }

--- a/intruder_alarm/src/list/tests.rs
+++ b/intruder_alarm/src/list/tests.rs
@@ -71,7 +71,7 @@ macro_rules! gen_cursor_tests {
     ($list:tt, $node_ctor:path) => {
         mod cursor {
             use super::*;
-            use ::{Cursor, CursorMut};
+            use ::CursorMut;
             use quickcheck::TestResult;
 
             quickcheck! {
@@ -792,7 +792,6 @@ mod unsafe_ref {
 
     mod push_node {
         use super::*;
-        use std::boxed::Box;
         use UnsafeRef;
 
         #[test]

--- a/intruder_alarm/src/stack/mod.rs
+++ b/intruder_alarm/src/stack/mod.rs
@@ -131,12 +131,10 @@ where
 {
     /// Push a node on to the stack.
     pub fn push_node(&mut self, mut node: Ref) -> &mut Self {
-        unsafe {
-            *node.next_mut() = self.top;
-            let node = Link::from_owning_ref(node);
-            self.top = node;
-            self.len += 1;
-        };
+        *node.next_mut() = self.top;
+        let node = Link::from_owning_ref(node);
+        self.top = node;
+        self.len += 1;
         self
     }
 }

--- a/intruder_alarm/src/stack/mod.rs
+++ b/intruder_alarm/src/stack/mod.rs
@@ -9,10 +9,12 @@
 //! like the allocator implementation itself, since each list element manages
 //! its own memory.
 use super::{Link, OwningRef, UnsafeRef};
-use core::iter::{Extend, FromIterator};
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::DerefMut;
+use core::{
+    iter::{Extend, FromIterator},
+    marker::PhantomData,
+    mem,
+    ops::DerefMut,
+};
 
 #[cfg(test)]
 mod tests;

--- a/intruder_alarm/src/stack/tests.rs
+++ b/intruder_alarm/src/stack/tests.rs
@@ -6,8 +6,7 @@
 //  directory of this repository for more information.
 //
 
-use super::Linked;
-use super::*;
+use super::{Linked, *};
 use quickcheck::TestResult;
 use std::default::Default;
 
@@ -22,7 +21,7 @@ pub type NumberedList = Stack<usize, NumberedNode, Box<NumberedNode>>;
 impl NumberedNode {
     pub fn new(number: usize) -> Self {
         NumberedNode {
-            number: number,
+            number,
             ..Default::default()
         }
     }

--- a/intruder_alarm/src/stack/tests.rs
+++ b/intruder_alarm/src/stack/tests.rs
@@ -229,7 +229,6 @@ mod unsafe_ref {
 
     mod push_node {
         use super::*;
-        use std::boxed::Box;
         use UnsafeRef;
 
         #[test]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,8 @@
 max_width = 80
-reorder_imported_names = true
-reorder_imports = true
-reorder_imports_in_group = true
+imports_indent = "Block"
+imports_layout = "HorizontalVertical"
+merge_imports = true
 match_block_trailing_comma = true
 wrap_comments = true
 use_try_shorthand = true
+use_field_init_shorthand = true


### PR DESCRIPTION
This branch removes some warnings, updates `rustfmt.toml` to remove no-longer-recognized configurations and add some new ones, and runs `rustfmt` on everything.

This should be trivial, & i'm going to just go ahead and merge it, pending CI.