### PR TITLE
feat(base): Add hal9000 dependency to base, and make frames `Page`s

### DIFF
--- a/alarm_base/Cargo.toml
+++ b/alarm_base/Cargo.toml
@@ -13,3 +13,6 @@ std = []
 
 [dependencies.spin]
 version = "0.4.6"
+
+[dependencies.hal9000]
+git = "https://github.com/sos-os/hal9000.git"

--- a/alarm_base/src/frame.rs
+++ b/alarm_base/src/frame.rs
@@ -1,16 +1,17 @@
 //! Base types for page frame allocators.
 use alloc::allocator::AllocErr;
+use hal9000::mem::Page;
 
 /// An allocator that provides page frames.
 pub unsafe trait Allocator {
     /// Architecture-dependent size of a physical page.
-    const FRAME_SIZE: usize;
+    const FRAME_SIZE: usize = <Self::Frame as Page>::SIZE;
 
     /// Type representing frames provided by this allocator.
     ///
     /// A `Frame` must either be a pointer to a contiguous block of `FRAME_SIZE`
     /// bytes, or be a handle that may be converted into such a pointer.
-    type Frame;
+    type Frame: Page;
 
     /// Returns a new `Frame`.
     unsafe fn alloc(&mut self) -> Result<Self::Frame, AllocErr>;

--- a/alarm_base/src/lib.rs
+++ b/alarm_base/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate core;
+extern crate hal9000;
 extern crate spin;
 
 pub mod frame;


### PR DESCRIPTION
This branch adds a dependency on `hal9000` to `alarm_base`, and
adds a bound that `FrameAllocator::Page: hal9000::mem::Page`. I
made this change in my buddy block allocator dev branch, but it never
made it to master, so I'm attempting to rectify that.