### PR TITLE
fix(intruder-alarm): remove 'shared' feature declaration

### DIFF
--- a/intruder-alarm/src/lib.rs
+++ b/intruder-alarm/src/lib.rs
@@ -32,7 +32,6 @@
     any(feature = "alloc", feature = "std", test),
     feature(box_into_raw_non_null)
 )]
-#![feature(shared)]
 #![feature(const_fn)]
 #![deny(missing_docs)]
 


### PR DESCRIPTION
Removes `#![feature(shared)]` because it is likely not needed with the current nightly rustc (1.31).