### PR TITLE
chore: Update crate for Rust 2018

### DIFF
--- a/alarm-base/Cargo.toml
+++ b/alarm-base/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 description = """
 Base types and API definitions shared across ALARM allocators.
 """
+edition = "2018"
 
 [features]
 default = ["lend"]

--- a/intruder-alarm/Cargo.toml
+++ b/intruder-alarm/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 description = """
 Intrusive collections for ALARM allocators.
 """
+edition = "2018"
 
 [features]
 std = []

--- a/intruder-alarm/src/cursor.rs
+++ b/intruder-alarm/src/cursor.rs
@@ -8,7 +8,7 @@
 //
 //! Cursors allowing bi-directional traversal of data structures.
 use core::{iter, ops};
-use OwningRef;
+use crate::OwningRef;
 
 //-----------------------------------------------------------------------------
 // Traits

--- a/intruder-alarm/src/list/mod.rs
+++ b/intruder-alarm/src/list/mod.rs
@@ -7,10 +7,10 @@
 //! use intrusive lists in code that runs without the kernel memory allocator,
 //! like the allocator implementation itself, since each list element manages
 //! its own memory.
-use cursor::{self, Cursor as CursorTrait};
-use Link;
-use OwningRef;
-use UnsafeRef;
+use crate::cursor::{self, Cursor as CursorTrait};
+use crate::Link;
+use crate::OwningRef;
+use crate::UnsafeRef;
 
 use core::{
     iter::{DoubleEndedIterator, Extend, FromIterator, Iterator},

--- a/intruder-alarm/src/list/tests.rs
+++ b/intruder-alarm/src/list/tests.rs
@@ -70,7 +70,7 @@ macro_rules! gen_cursor_tests {
     ($list:tt, $node_ctor:path) => {
         mod cursor {
             use super::*;
-            use ::CursorMut;
+            use crate::CursorMut;
             use quickcheck::TestResult;
 
             quickcheck! {
@@ -783,7 +783,7 @@ mod boxed {
 
 mod unsafe_ref {
     use super::*;
-    use UnsafeRef;
+    use crate::UnsafeRef;
 
     pub type UnsafeList = List<usize, NumberedNode, UnsafeRef<NumberedNode>>;
 
@@ -791,7 +791,7 @@ mod unsafe_ref {
 
     mod push_node {
         use super::*;
-        use UnsafeRef;
+        use crate::UnsafeRef;
 
         #[test]
         fn not_empty_after_first_push() {

--- a/intruder-alarm/src/stack/tests.rs
+++ b/intruder-alarm/src/stack/tests.rs
@@ -222,13 +222,13 @@ mod boxed {
 
 mod unsafe_ref {
     use super::*;
-    use UnsafeRef;
+    use crate::UnsafeRef;
 
     pub type UnsafeList = Stack<usize, NumberedNode, UnsafeRef<NumberedNode>>;
 
     mod push_node {
         use super::*;
-        use UnsafeRef;
+        use crate::UnsafeRef;
 
         #[test]
         fn not_empty_after_first_push() {

--- a/slabby/Cargo.toml
+++ b/slabby/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 description = """
 Slab allocators composable on top of ALARM memory allocators.
 """
+edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Update crate for Rust 2018 using 'cargo fix --edition'